### PR TITLE
Allow sync bot to run for 15 minutes

### DIFF
--- a/bots/sync/package.json
+++ b/bots/sync/package.json
@@ -53,7 +53,7 @@
 				"time": "0 */10 * * * ?"
 			},
 			"memory": 1536,
-			"timeout": 300,
+			"timeout": 900,
 			"VpcConfig": {
 				"SecurityGroupIds": [
 					{


### PR DESCRIPTION
The sync bot should have a timeout of 15 minutes instead of 5 minutes.